### PR TITLE
feat: expose the lifecycle policy image retention count

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_arns"></a> [allowed\_arns](#input\_allowed\_arns) | The list of IAM user arns that are allowed to push and pull to and from the repository | `list(string)` | n/a | yes |
+| <a name="input_image_retention_count"></a> [image\_retention\_count](#input\_image\_retention\_count) | Number of most recent images the lifecycle policy keeps. Older images expire. | `number` | `30` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. One of MUTABLE, IMMUTABLE, IMMUTABLE\_WITH\_EXCLUSION, or MUTABLE\_WITH\_EXCLUSION. | `string` | `"MUTABLE"` | no |
 | <a name="input_image_tag_mutability_exclusion_filter"></a> [image\_tag\_mutability\_exclusion\_filter](#input\_image\_tag\_mutability\_exclusion\_filter) | Tags excluded from the mutability setting. Only applies when image\_tag\_mutability is IMMUTABLE\_WITH\_EXCLUSION or MUTABLE\_WITH\_EXCLUSION. | <pre>list(object({<br/>    filter      = string<br/>    filter_type = optional(string, "WILDCARD")<br/>  }))</pre> | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the image repository that we are going to create | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -27,24 +27,22 @@ resource "aws_ecr_repository" "this" {
 resource "aws_ecr_lifecycle_policy" "this" {
   repository = aws_ecr_repository.this.name
 
-  policy = <<EOF
-{
-    "rules": [
-        {
-            "rulePriority": 1,
-            "description": "only keep 30 builds",
-            "selection": {
-                "tagStatus": "any",
-                "countType": "imageCountMoreThan",
-                "countNumber": 30
-            },
-            "action": {
-                "type": "expire"
-            }
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "only keep ${var.image_retention_count} builds"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.image_retention_count
         }
+        action = {
+          type = "expire"
+        }
+      }
     ]
-}
-EOF
+  })
 }
 
 // Create aws ecr repository that allows a list of arns to push and pull from it

--- a/tests/unit/retention.tftest.hcl
+++ b/tests/unit/retention.tftest.hcl
@@ -1,0 +1,66 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+}
+
+run "retention_count_reaches_the_policy" {
+  command = plan
+
+  variables {
+    name                  = "backend"
+    allowed_arns          = ["arn:aws:iam::123456789012:root"]
+    image_retention_count = 200
+  }
+
+  assert {
+    condition     = one(jsondecode(aws_ecr_lifecycle_policy.this.policy).rules).selection.countNumber == 200
+    error_message = "image_retention_count must drive countNumber"
+  }
+
+  assert {
+    condition     = one(jsondecode(aws_ecr_lifecycle_policy.this.policy).rules).description == "only keep 200 builds"
+    error_message = "the rule description must report the configured count"
+  }
+}
+
+run "defaults_preserve_thirty" {
+  command = plan
+
+  variables {
+    name         = "backend"
+    allowed_arns = ["arn:aws:iam::123456789012:root"]
+  }
+
+  assert {
+    condition     = one(jsondecode(aws_ecr_lifecycle_policy.this.policy).rules).selection.countNumber == 30
+    error_message = "default must stay 30 so existing consumers see no behavior change"
+  }
+}
+
+run "selection_criteria_are_unchanged" {
+  command = plan
+
+  variables {
+    name                  = "backend"
+    allowed_arns          = ["arn:aws:iam::123456789012:root"]
+    image_retention_count = 200
+  }
+
+  assert {
+    condition     = one(jsondecode(aws_ecr_lifecycle_policy.this.policy).rules).selection.tagStatus == "any"
+    error_message = "the rule must select every image regardless of tag"
+  }
+
+  assert {
+    condition     = one(jsondecode(aws_ecr_lifecycle_policy.this.policy).rules).selection.countType == "imageCountMoreThan"
+    error_message = "count-based selection keeps the newest images and never empties the repository"
+  }
+
+  assert {
+    condition     = one(jsondecode(aws_ecr_lifecycle_policy.this.policy).rules).action.type == "expire"
+    error_message = "expire is the only action ECR supports"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,13 @@ variable "image_tag_mutability_exclusion_filter" {
   default     = []
 }
 
+variable "image_retention_count" {
+  type        = number
+  description = "Number of most recent images the lifecycle policy keeps. Older images expire."
+  default     = 30
+
+  validation {
+    condition     = var.image_retention_count >= 1
+    error_message = "image_retention_count must be at least 1."
+  }
+}


### PR DESCRIPTION
Closes #35.

## What changed

`image_retention_count` sets how many of the most recent images the lifecycle policy keeps. It is a number, defaults to 30, and validates as at least 1.

The policy now builds through `jsonencode` instead of a heredoc. The count reaches `countNumber` and the rule description from one expression, so the description stays accurate when a consumer raises the count.

## Compatibility

The default holds the current behavior. Consumers pin their own `?ref` and see nothing until they bump it. This releases as a minor version.

`jsonencode` sorts object keys alphabetically, so the policy string differs from the heredoc. ECR normalizes the document it stores, so the first plan after a consumer bumps the ref may show an in-place update to `aws_ecr_lifecycle_policy.this.policy` with the rules unchanged.

## Testing

`terraform test -test-directory=tests/unit` passes, 6 runs across 3 files.

`tests/unit/retention.tftest.hcl` covers a passed count of 200 reaching `countNumber` and the description, the default of 30, and the selection criteria that keep the rule count-based. A count rule always keeps the newest N images, so the repository never empties. An age-based rule would expire everything once pushes stopped for the configured number of days.

## Follow-up

`synapsestudios/velocigent.ai-infrastructure#316` bumps the `backend` repository to 200 once this releases.
